### PR TITLE
Replaces chalk with picocolors & fixes Hermes runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: dist
+          path: ./dist
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ docs/.vuepress/.cache
 
 # other environments
 deno.lock
+
+# intellij
+.idea

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -86,14 +86,14 @@ property of the [UserConfiguration](#user-configuration).
 
 ### LevelConfiguration Interface
 
-> Refer to the [ChalkJS documentation](https://github.com/chalk/chalk?tab=readme-ov-file#styles) for information about terminal style values.
+> Refer to the [picocolors documentation](https://github.com/alexeyraspopov/picocolors#usage) for information about terminal style values.
 
 ```typescript
 interface LevelConfiguration {
   levelName: string;
   level: number;
   style: string;
-  terminalStyle: ChalkStyle[];
+  terminalStyle: ConsoleStyle[];
   method: Method;
   emoji: string;
 }
@@ -210,12 +210,12 @@ to change the padding based on the browser environment. These functions are also
 
 ### Default Server Styles
 
-Adze styling for the server makes use of a library named [Chalk](https://github.com/chalk/chalk).
-Chalk exposes several formatting functions for server text styling that Adze exposes in its
+Adze styling for the server makes use of a library named [picocolors](https://github.com/alexeyraspopov/picocolors).
+picocolors exposes several formatting functions for server text styling that Adze exposes in its
 configuration.
 
-For a list of styles available for use with Chalk, refer to the
-[Chalk styles documentation](https://github.com/chalk/chalk?tab=readme-ov-file#styles).
+For a list of styles available for use with picocolors, refer to the
+[picocolors styles documentation](https://github.com/alexeyraspopov/picocolors#usage).
 
 #### Default Level Styles
 

--- a/index.html
+++ b/index.html
@@ -38,7 +38,8 @@
       {
         "imports": {
           "./src": "./dist/index.js",
-          "chalk": "./dist/functions/chalk-dummy.js",
+          "picocolors": "./dist/functions/picocolors-dummy.js",
+          "@ungap/structured-clone": "/node_modules/@ungap/structured-clone/esm/index.js",
           "date-fns/formatISO": "/node_modules/date-fns/formatISO.mjs",
           "date-fns/format": "/node_modules/date-fns/format.mjs"
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@ungap/structured-clone": "1.2.0",
-        "chalk": "^5.3.0",
         "date-fns": "^3.6.0",
         "picocolors": "1.1.1"
       },
@@ -3112,6 +3111,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
       "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "dev": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -11384,7 +11384,8 @@
     "chalk": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w=="
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "dev": true
     },
     "chardet": {
       "version": "0.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@ungap/structured-clone": "1.2.0",
         "chalk": "^5.3.0",
-        "date-fns": "^3.6.0"
+        "date-fns": "^3.6.0",
+        "picocolors": "1.1.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.5.0",
@@ -18,6 +20,7 @@
         "@types/eslint__js": "^8.42.3",
         "@types/eslint-config-prettier": "^6.11.3",
         "@types/jsdom": "^21.1.7",
+        "@types/ungap__structured-clone": "1.2.0",
         "@vitest/ui": "^2.0.5",
         "@vuepress/bundler-vite": "^2.0.0-rc.7",
         "@vuepress/plugin-markdown-container": "^2.0.0-rc.42",
@@ -1477,6 +1480,12 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true
     },
+    "node_modules/@types/ungap__structured-clone": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/ungap__structured-clone/-/ungap__structured-clone-1.2.0.tgz",
+      "integrity": "sha512-ZoaihZNLeZSxESbk9PUAPZOlSpcKx81I1+4emtULDVmBLkYutTcMlCj2K9VNlf9EWODxdO6gkAqEaLorXwZQVA==",
+      "dev": true
+    },
     "node_modules/@types/web-bluetooth": {
       "version": "0.0.20",
       "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
@@ -1696,8 +1705,7 @@
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
-      "dev": true
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "5.1.2",
@@ -6714,10 +6722,9 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -10072,8 +10079,7 @@
       "version": "11.1.4",
       "resolved": "https://registry.npmjs.org/@size-limit/file/-/file-11.1.4.tgz",
       "integrity": "sha512-QxnGj9cxhCEuqMAV01gqonXIKcc+caZqFHZpV51oL2ZJNGSPP9Q/yyf+7HbVe00faOFd1dZZwMwzZmX7HQ9LbA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@size-limit/preset-small-lib": {
       "version": "11.1.4",
@@ -10263,6 +10269,12 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true
     },
+    "@types/ungap__structured-clone": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/ungap__structured-clone/-/ungap__structured-clone-1.2.0.tgz",
+      "integrity": "sha512-ZoaihZNLeZSxESbk9PUAPZOlSpcKx81I1+4emtULDVmBLkYutTcMlCj2K9VNlf9EWODxdO6gkAqEaLorXwZQVA==",
+      "dev": true
+    },
     "@types/web-bluetooth": {
       "version": "0.0.20",
       "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
@@ -10388,15 +10400,13 @@
     "@ungap/structured-clone": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
-      "dev": true
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
     },
     "@vitejs/plugin-vue": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.1.2.tgz",
       "integrity": "sha512-nY9IwH12qeiJqumTCLJLE7IiNx7HZ39cbHaysEUd+Myvbz9KAqd2yq+U01Kab1R/H1BmiyM2ShTYlNH32Fzo3A==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@vitest/expect": {
       "version": "2.0.5",
@@ -10695,8 +10705,7 @@
       "version": "2.0.0-rc.41",
       "resolved": "https://registry.npmjs.org/@vuepress/highlighter-helper/-/highlighter-helper-2.0.0-rc.41.tgz",
       "integrity": "sha512-MaZhWpjL2baw1+IyBRUcH84rIA/qx6FxoHpfvxr90VqNjCSnjJZ09zY+1vXAdvie0Z5rMHEmziO+eX0DHmWQzw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@vuepress/markdown": {
       "version": "2.0.0-rc.14",
@@ -11069,8 +11078,7 @@
           "version": "0.14.10",
           "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
           "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -11093,8 +11101,7 @@
           "version": "0.14.10",
           "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
           "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -11108,8 +11115,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "8.3.3",
@@ -12088,8 +12094,7 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-scope": {
       "version": "7.2.2",
@@ -13547,8 +13552,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-9.0.1.tgz",
       "integrity": "sha512-cBt7aAzmkfX8X7FqAe8EBryiKmToXgMQEEMqkXzWCm0toDtfDYIGboKeTKd8cpNJArJtutrf+977wFJTsvNGmQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "markdown-it-container": {
       "version": "4.0.0",
@@ -13955,10 +13959,9 @@
       "dev": true
     },
     "picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "picomatch": {
       "version": "2.3.1",
@@ -14717,8 +14720,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
       "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ts-node": {
       "version": "10.9.2",
@@ -15477,8 +15479,7 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xml-name-validator": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "adze",
   "description": "A universal, modern, and extendable logging library for JavaScript and TypeScript.",
   "version": "2.0.0",
-  "main": "index.js",
+  "main": "dist/index.js",
   "type": "module",
   "engines": {
     "node": ">=18.19.0"
@@ -57,6 +57,7 @@
     "@types/eslint__js": "^8.42.3",
     "@types/eslint-config-prettier": "^6.11.3",
     "@types/jsdom": "^21.1.7",
+    "@types/ungap__structured-clone": "1.2.0",
     "@vitest/ui": "^2.0.5",
     "@vuepress/bundler-vite": "^2.0.0-rc.7",
     "@vuepress/plugin-markdown-container": "^2.0.0-rc.42",
@@ -87,8 +88,10 @@
     "**/*.{js,ts}": "eslint --fix"
   },
   "dependencies": {
+    "@ungap/structured-clone": "1.2.0",
+    "chalk": "^5.3.0",
     "date-fns": "^3.6.0",
-    "chalk": "^5.3.0"
+    "picocolors": "1.1.1"
   },
   "size-limit": [
     {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
   },
   "dependencies": {
     "@ungap/structured-clone": "1.2.0",
-    "chalk": "^5.3.0",
     "date-fns": "^3.6.0",
     "picocolors": "1.1.1"
   },

--- a/src/_types/log.ts
+++ b/src/_types/log.ts
@@ -1,4 +1,4 @@
-import adze, { ChalkStyle, ConfigurationData } from '..';
+import adze, { ConsoleStyle, ConfigurationData } from '..';
 import {
   methodsWithArgs,
   levels,
@@ -100,7 +100,7 @@ export interface LevelConfiguration {
   levelName: string;
   level: number;
   style: string;
-  terminalStyle: ChalkStyle[];
+  terminalStyle: ConsoleStyle[];
   method: Method;
   emoji: string;
 }

--- a/src/_types/styles.ts
+++ b/src/_types/styles.ts
@@ -8,7 +8,6 @@ const styles_raw = [
   'cyan',
   'white',
   'gray',
-  'grey',
   'blackBright',
   'redBright',
   'greenBright',
@@ -25,8 +24,6 @@ const styles_raw = [
   'bgMagenta',
   'bgCyan',
   'bgWhite',
-  'bgGray',
-  'bgGrey',
   'bgBlackBright',
   'bgRedBright',
   'bgGreenBright',
@@ -43,15 +40,15 @@ const styles_raw = [
   'inverse',
   'hidden',
   'strikethrough',
-  'visible',
 ] as const;
 
+type StylesRaw = typeof styles_raw;
 /**
- * String union representing all possible Chalk styles.
+ * String union representing all possible Console styles.
  */
-export type ChalkStyle = (typeof styles_raw)[number];
+export type ConsoleStyle = StylesRaw[number];
 
 /**
- * Immutable array of all possible chalk styles.
+ * Immutable array of all possible console styles.
  */
-export const chalk_styles = Object.freeze(styles_raw);
+export const console_styles = Object.freeze(styles_raw);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -248,7 +248,7 @@ export function getLogConfig(overrides: Partial<LevelConfiguration> = {}): Level
     level: 6,
     style:
       'font-size: 12px; border-radius: 4px; padding-right: 51px; background: linear-gradient(to right, #ecedef, #d9dce0); color: #333435; border-color: #bfc1c5;',
-    terminalStyle: ['white', 'bgGray'],
+    terminalStyle: ['white', 'bgBlackBright'],
     method: 'log',
     emoji: '🪵',
     ...overrides,

--- a/src/formatters/pretty/pretty.ts
+++ b/src/formatters/pretty/pretty.ts
@@ -1,7 +1,7 @@
 import Formatter from '../formatter';
 import {
   addPadding,
-  applyChalkStyles,
+  applyStyles,
   formatAssert,
   formatCount,
   formatIf,
@@ -36,7 +36,7 @@ export default class PrettyFormatter extends Formatter {
     const leader = `${leaderRaw} `;
     const meta = this.formatMeta(mods, timestamp);
 
-    const styledLeader = applyChalkStyles(leader, this.level.terminalStyle);
+    const styledLeader = applyStyles(leader, this.level.terminalStyle);
 
     message.push(styledLeader);
     meta !== '' ? message.push(meta) : null;

--- a/src/functions/chalk-dummy.ts
+++ b/src/functions/chalk-dummy.ts
@@ -1,4 +1,0 @@
-/* eslint-disable */
-export class Chalk {
-  constructor(_: { level: 0 | 1 | 2 | 3 }) {}
-}

--- a/src/functions/global.ts
+++ b/src/functions/global.ts
@@ -47,7 +47,12 @@ export function isGlobalInitialized(global: unknown): global is AdzeGlobal {
  * Validates that the current environment is `Window`.
  */
 export function isBrowser(): boolean {
-  return typeof window !== 'undefined' && !isDeno();
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.location !== 'undefined' &&
+    typeof window.navigator.userAgent !== 'undefined' &&
+    !isDeno()
+  );
 }
 
 /**

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -1,4 +1,4 @@
-export * from './chalk-dummy';
+export * from './picocolors-dummy';
 export * from './data';
 export * from './filters';
 export * from './formatters';

--- a/src/functions/picocolors-dummy.ts
+++ b/src/functions/picocolors-dummy.ts
@@ -1,0 +1,2 @@
+/* eslint-disable */
+export const picocolors = {};

--- a/src/functions/picocolors-loader.ts
+++ b/src/functions/picocolors-loader.ts
@@ -1,0 +1,4 @@
+import * as _picocolors from 'picocolors';
+
+//@ts-expect-error - This is workaround for not having picocolors exported as esm module.
+export const picocolors = (_picocolors.default ?? _picocolors) as typeof _picocolors;

--- a/src/functions/seal.ts
+++ b/src/functions/seal.ts
@@ -2,6 +2,7 @@
 import { Modifier, ModifierData } from '..';
 import { Configuration } from '../configuration';
 import Log from '../log';
+import structuredClone from '@ungap/structured-clone';
 
 /**
  * Required type for creating mixins in TypeScript.

--- a/src/functions/util.ts
+++ b/src/functions/util.ts
@@ -1,5 +1,5 @@
-import { Chalk } from 'chalk';
-import { ChalkStyle, Configuration } from '..';
+import { picocolors } from './picocolors-loader';
+import { ConsoleStyle, Configuration } from '..';
 import Log from '../log';
 
 /**
@@ -37,16 +37,15 @@ export function addPadding(str: string, withEmoji = false, emoji?: string): stri
 }
 
 /**
- * Applies array of chalk styles to the provided string. An optional terminal color fidelity
+ * Applies array of console styles to the provided string. An optional terminal color fidelity
  * value can be passed to enable different color fidelities for different terminals.
  *
- * Refer to https://github.com/chalk/chalk#chalklevel
+ * Refer to https://github.com/alexeyraspopov/picocolors#usage
  */
-export function applyChalkStyles(str: string, styles: ChalkStyle[]): string {
-  // Force chalk colors
-  const chalk = new Chalk();
-  return styles.reduce((acc, style) => {
-    return chalk[style](acc);
+export function applyStyles(str: string, styles: ConsoleStyle[]): string {
+  // Force console colors
+  return styles.reduce<string>((acc, style) => {
+    return picocolors[style](acc);
   }, str);
 }
 

--- a/test/configuration.server.test.ts
+++ b/test/configuration.server.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import adze, { setup, teardown } from '../src';
-import { applyChalkStyles } from '../src/functions';
+import { applyStyles } from '../src/functions';
 
 /**
  * @vitest-environment node
@@ -31,7 +31,7 @@ describe('Configuration', () => {
     adze.withEmoji.error('This is an error log with overwritten style configuration.');
 
     expect(console.error).toHaveBeenCalledWith(
-      applyChalkStyles('🔥 Error     ', ['magenta', 'bgWhite']),
+      applyStyles('🔥 Error     ', ['magenta', 'bgWhite']),
       'This is an error log with overwritten style configuration.'
     );
   });

--- a/test/formatters/formatting.test.ts
+++ b/test/formatters/formatting.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import adze, { teardown } from '../../src';
-import { applyChalkStyles } from '../../src/functions';
+import { applyStyles } from '../../src/functions';
 import { getLogConfig } from '../../src/constants';
 
 /**
@@ -19,7 +19,7 @@ describe('log formatting', () => {
     adze.format('bad').log('Testing bad formatting modifier.');
 
     expect(console.log).toHaveBeenCalledWith(
-      applyChalkStyles(' Log       ', getLogConfig().terminalStyle),
+      applyStyles(' Log       ', getLogConfig().terminalStyle),
       'Testing bad formatting modifier.'
     );
     expect(console.warn).toHaveBeenCalledTimes(1);

--- a/test/formatters/pretty/modifiers.server.test.ts
+++ b/test/formatters/pretty/modifiers.server.test.ts
@@ -1,7 +1,7 @@
 import { JSDOM } from 'jsdom';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import adze, { setup, TableData, teardown } from '../../../src';
-import { applyChalkStyles } from '../../../src/functions';
+import { applyStyles } from '../../../src/functions';
 import { getLogConfig } from '../../../src/constants';
 
 /**
@@ -23,13 +23,13 @@ describe('modifiers with pretty format in node', () => {
 
     expect(console.log).toHaveBeenNthCalledWith(
       1,
-      applyChalkStyles(' Log       ', getLogConfig().terminalStyle),
+      applyStyles(' Log       ', getLogConfig().terminalStyle),
       '[timer] ',
       'Test timer.'
     );
     expect(console.log).toHaveBeenNthCalledWith(
       2,
-      applyChalkStyles(' Log       ', getLogConfig().terminalStyle),
+      applyStyles(' Log       ', getLogConfig().terminalStyle),
       '[timer] (Time elapsed: 0s 0ms)',
       'Test timer.'
     );
@@ -43,7 +43,7 @@ describe('modifiers with pretty format in node', () => {
     adze.label('timer').timeNow.log('Test timer.');
 
     expect(console.log).toHaveBeenCalledWith(
-      applyChalkStyles(' Log       ', getLogConfig().terminalStyle),
+      applyStyles(' Log       ', getLogConfig().terminalStyle),
       '[timer] (Time elapsed: 0s 0ms)',
       'Test timer.'
     );
@@ -60,7 +60,7 @@ describe('modifiers with pretty format in node', () => {
     for (let i = 1; i <= amount; i++) {
       expect(console.log).toHaveBeenNthCalledWith(
         i,
-        applyChalkStyles(' Log       ', getLogConfig().terminalStyle),
+        applyStyles(' Log       ', getLogConfig().terminalStyle),
         `[counter] (Count: ${i}) `,
         'Counting log.'
       );
@@ -77,7 +77,7 @@ describe('modifiers with pretty format in node', () => {
     adze.label('counter').countClear.log('Clearing count.');
     expect(console.log).toHaveBeenNthCalledWith(
       6,
-      applyChalkStyles(' Log       ', getLogConfig().terminalStyle),
+      applyStyles(' Log       ', getLogConfig().terminalStyle),
       '[counter] ',
       'Clearing count.'
     );
@@ -93,7 +93,7 @@ describe('modifiers with pretty format in node', () => {
     adze.label('counter').countReset.log('Resetting count.');
     expect(console.log).toHaveBeenNthCalledWith(
       6,
-      applyChalkStyles(' Log       ', getLogConfig().terminalStyle),
+      applyStyles(' Log       ', getLogConfig().terminalStyle),
       '[counter] (Count: 0) ',
       'Resetting count.'
     );
@@ -129,7 +129,7 @@ describe('modifiers with pretty format in node', () => {
     console.group = vi.fn();
     adze.group.log('Grouping logs.');
     expect(console.group).toHaveBeenCalledWith(
-      applyChalkStyles(' Log       ', getLogConfig().terminalStyle),
+      applyStyles(' Log       ', getLogConfig().terminalStyle),
       'Grouping logs.'
     );
   });
@@ -138,7 +138,7 @@ describe('modifiers with pretty format in node', () => {
     console.groupCollapsed = vi.fn();
     adze.groupCollapsed.log('Grouping logs.');
     expect(console.groupCollapsed).toHaveBeenCalledWith(
-      applyChalkStyles(' Log       ', getLogConfig().terminalStyle),
+      applyStyles(' Log       ', getLogConfig().terminalStyle),
       'Grouping logs.'
     );
   });
@@ -147,7 +147,7 @@ describe('modifiers with pretty format in node', () => {
     console.groupCollapsed = vi.fn();
     adze.groupCollapsed.log('Grouping logs.');
     expect(console.groupCollapsed).toHaveBeenCalledWith(
-      applyChalkStyles(' Log       ', getLogConfig().terminalStyle),
+      applyStyles(' Log       ', getLogConfig().terminalStyle),
       'Grouping logs.'
     );
   });
@@ -158,7 +158,7 @@ describe('modifiers with pretty format in node', () => {
     adze.group.log('Grouping logs.');
     adze.groupEnd.log();
     expect(console.group).toHaveBeenCalledWith(
-      applyChalkStyles(' Log       ', getLogConfig().terminalStyle),
+      applyStyles(' Log       ', getLogConfig().terminalStyle),
       'Grouping logs.'
     );
     expect(console.groupEnd).toHaveBeenCalled();
@@ -168,7 +168,7 @@ describe('modifiers with pretty format in node', () => {
     console.log = vi.fn();
     adze.label('test').log('Test log.');
     expect(console.log).toHaveBeenCalledWith(
-      applyChalkStyles(' Log       ', getLogConfig().terminalStyle),
+      applyStyles(' Log       ', getLogConfig().terminalStyle),
       '[test] ',
       'Test log.'
     );
@@ -178,7 +178,7 @@ describe('modifiers with pretty format in node', () => {
     console.log = vi.fn();
     adze.namespace('foo', 'bar').log('Test log.');
     expect(console.log).toHaveBeenCalledWith(
-      applyChalkStyles(' Log       ', getLogConfig().terminalStyle),
+      applyStyles(' Log       ', getLogConfig().terminalStyle),
       '#foo #bar ',
       'Test log.'
     );
@@ -188,7 +188,7 @@ describe('modifiers with pretty format in node', () => {
     console.log = vi.fn();
     adze.ns('foo', 'bar').log('Test log.');
     expect(console.log).toHaveBeenCalledWith(
-      applyChalkStyles(' Log       ', getLogConfig().terminalStyle),
+      applyStyles(' Log       ', getLogConfig().terminalStyle),
       '#foo #bar ',
       'Test log.'
     );
@@ -199,7 +199,7 @@ describe('modifiers with pretty format in node', () => {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     adze.if(2 === 2).log('Test log.');
     expect(console.log).toHaveBeenCalledWith(
-      applyChalkStyles(' Log       ', getLogConfig().terminalStyle),
+      applyStyles(' Log       ', getLogConfig().terminalStyle),
       'Expression passed:',
       'Test log.'
     );
@@ -210,7 +210,7 @@ describe('modifiers with pretty format in node', () => {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     adze.withEmoji.if(2 === 2).log('Test log.');
     expect(console.log).toHaveBeenCalledWith(
-      applyChalkStyles('🪵 Log       ', getLogConfig().terminalStyle),
+      applyStyles('🪵 Log       ', getLogConfig().terminalStyle),
       '✅ Expression passed:',
       'Test log.'
     );
@@ -222,7 +222,7 @@ describe('modifiers with pretty format in node', () => {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     adze.assert(2 === 3).log('Test log.');
     expect(console.log).toHaveBeenCalledWith(
-      applyChalkStyles(' Log       ', getLogConfig().terminalStyle),
+      applyStyles(' Log       ', getLogConfig().terminalStyle),
       'Assertion failed:',
       'Test log.'
     );
@@ -234,7 +234,7 @@ describe('modifiers with pretty format in node', () => {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     adze.withEmoji.assert(2 === 3).log('Test log.');
     expect(console.log).toHaveBeenCalledWith(
-      applyChalkStyles('🪵 Log       ', getLogConfig().terminalStyle),
+      applyStyles('🪵 Log       ', getLogConfig().terminalStyle),
       '❌ Assertion failed:',
       'Test log.'
     );
@@ -247,7 +247,7 @@ describe('modifiers with pretty format in node', () => {
     });
     adze.timestamp.log('Test log.');
     expect(console.log).toHaveBeenCalledWith(
-      applyChalkStyles(' Log       ', getLogConfig().terminalStyle),
+      applyStyles(' Log       ', getLogConfig().terminalStyle),
       '2024-08-03T16:37:11-04:00 ',
       'Test log.'
     );
@@ -258,9 +258,7 @@ describe('modifiers with pretty format in node', () => {
     const store = setup();
     store.addListener('log', (log) => {
       if (log.data) {
-        expect(log.data.message[0]).toBe(
-          applyChalkStyles(' Log       ', getLogConfig().terminalStyle)
-        );
+        expect(log.data.message[0]).toBe(applyStyles(' Log       ', getLogConfig().terminalStyle));
         expect(log.data.message[1]).toBe('Test log.');
         expect(log.data.stacktrace).toBeTruthy();
       } else {

--- a/test/formatters/pretty/terminators.server.test.ts
+++ b/test/formatters/pretty/terminators.server.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import adze, { LevelConfiguration, setup, teardown } from '../../../src';
-import { applyChalkStyles } from '../../../src/functions';
+import { applyStyles } from '../../../src/functions';
 import {
   getAlertConfig,
   getDebugConfig,
@@ -24,70 +24,70 @@ describe('terminators with pretty format in node stdout', () => {
 
   test('prints a log with level of alert', () => {
     console.error = vi.fn();
-    const chalkStyles = getAlertConfig().terminalStyle;
+    const consoleStyles = getAlertConfig().terminalStyle;
     adze.alert('This is an alert log.');
     expect(console.error).toHaveBeenCalledWith(
-      applyChalkStyles(' Alert     ', chalkStyles),
+      applyStyles(' Alert     ', consoleStyles),
       'This is an alert log.'
     );
   });
 
   test('prints a log with level of error', () => {
     console.error = vi.fn();
-    const chalkStyles = getErrorConfig().terminalStyle;
+    const consoleStyles = getErrorConfig().terminalStyle;
     adze.error('This is an error log.');
     expect(console.error).toHaveBeenCalledWith(
-      applyChalkStyles(' Error     ', chalkStyles),
+      applyStyles(' Error     ', consoleStyles),
       'This is an error log.'
     );
   });
 
   test('prints a log with level of warn', () => {
     console.warn = vi.fn();
-    const chalkStyles = getWarnConfig().terminalStyle;
+    const consoleStyles = getWarnConfig().terminalStyle;
     adze.warn('This is a warn log.');
     expect(console.warn).toHaveBeenCalledWith(
-      applyChalkStyles(' Warn      ', chalkStyles),
+      applyStyles(' Warn      ', consoleStyles),
       'This is a warn log.'
     );
   });
 
   test('prints a log with level of info', () => {
     console.info = vi.fn();
-    const chalkStyles = getInfoConfig().terminalStyle;
+    const consoleStyles = getInfoConfig().terminalStyle;
     adze.info('This is an info log.');
     expect(console.info).toHaveBeenCalledWith(
-      applyChalkStyles(' Info      ', chalkStyles),
+      applyStyles(' Info      ', consoleStyles),
       'This is an info log.'
     );
   });
 
   test('prints a log with level of fail', () => {
     console.info = vi.fn();
-    const chalkStyles = getFailConfig().terminalStyle;
+    const consoleStyles = getFailConfig().terminalStyle;
     adze.fail('This is a fail log.');
     expect(console.info).toHaveBeenCalledWith(
-      applyChalkStyles(' Fail      ', chalkStyles),
+      applyStyles(' Fail      ', consoleStyles),
       'This is a fail log.'
     );
   });
 
   test('prints a log with level of success', () => {
     console.info = vi.fn();
-    const chalkStyles = getSuccessConfig().terminalStyle;
+    const consoleStyles = getSuccessConfig().terminalStyle;
     adze.success('This is a success log.');
     expect(console.info).toHaveBeenCalledWith(
-      applyChalkStyles(' Success   ', chalkStyles),
+      applyStyles(' Success   ', consoleStyles),
       'This is a success log.'
     );
   });
 
   test('prints a log with level of log', () => {
     console.log = vi.fn();
-    const chalkStyles = getLogConfig().terminalStyle;
+    const consoleStyles = getLogConfig().terminalStyle;
     adze.log('This is a log log.');
     expect(console.log).toHaveBeenCalledWith(
-      applyChalkStyles(' Log       ', chalkStyles),
+      applyStyles(' Log       ', consoleStyles),
       'This is a log log.'
     );
   });
@@ -95,10 +95,10 @@ describe('terminators with pretty format in node stdout', () => {
   test('prints a log with level of debug', () => {
     console.debug = vi.fn();
     setup({ activeLevel: 'debug' });
-    const chalkStyles = getDebugConfig().terminalStyle;
+    const consoleStyles = getDebugConfig().terminalStyle;
     adze.debug('This is a debug log.');
     expect(console.debug).toHaveBeenCalledWith(
-      applyChalkStyles(' Debug     ', chalkStyles),
+      applyStyles(' Debug     ', consoleStyles),
       'This is a debug log.'
     );
   });
@@ -106,10 +106,10 @@ describe('terminators with pretty format in node stdout', () => {
   test('prints a log with level of verbose', () => {
     console.debug = vi.fn();
     setup({ activeLevel: 'verbose' });
-    const chalkStyles = getVerboseConfig().terminalStyle;
+    const consoleStyles = getVerboseConfig().terminalStyle;
     adze.verbose('This is a verbose log.');
     expect(console.debug).toHaveBeenCalledWith(
-      applyChalkStyles(' Verbose   ', chalkStyles),
+      applyStyles(' Verbose   ', consoleStyles),
       'This is a verbose log.'
     );
   });
@@ -130,7 +130,7 @@ describe('terminators with pretty format in node stdout', () => {
     adze.custom('leetLevel', 'This is a custom log.');
 
     expect(console.log).toHaveBeenCalledWith(
-      applyChalkStyles(' LeetLevel ', leetLevel.terminalStyle),
+      applyStyles(' LeetLevel ', leetLevel.terminalStyle),
       'This is a custom log.'
     );
   });
@@ -143,70 +143,70 @@ describe('terminators with emoji', () => {
 
   test('prints a log with level of alert with an emoji', () => {
     console.error = vi.fn();
-    const chalkStyles = getAlertConfig().terminalStyle;
+    const consoleStyles = getAlertConfig().terminalStyle;
     adze.withEmoji.alert('This is an alert log.');
     expect(console.error).toHaveBeenCalledWith(
-      applyChalkStyles('🚨 Alert     ', chalkStyles),
+      applyStyles('🚨 Alert     ', consoleStyles),
       'This is an alert log.'
     );
   });
 
   test('prints a log with level of error with an emoji', () => {
     console.error = vi.fn();
-    const chalkStyles = getErrorConfig().terminalStyle;
+    const consoleStyles = getErrorConfig().terminalStyle;
     adze.withEmoji.error('This is an error log.');
     expect(console.error).toHaveBeenCalledWith(
-      applyChalkStyles('🔥 Error     ', chalkStyles),
+      applyStyles('🔥 Error     ', consoleStyles),
       'This is an error log.'
     );
   });
 
   test('prints a log with level of warn with an emoji', () => {
     console.warn = vi.fn();
-    const chalkStyles = getWarnConfig().terminalStyle;
+    const consoleStyles = getWarnConfig().terminalStyle;
     adze.withEmoji.warn('This is a warn log.');
     expect(console.warn).toHaveBeenCalledWith(
-      applyChalkStyles('🔔 Warn      ', chalkStyles),
+      applyStyles('🔔 Warn      ', consoleStyles),
       'This is a warn log.'
     );
   });
 
   test('prints a log with level of info with an emoji', () => {
     console.info = vi.fn();
-    const chalkStyles = getInfoConfig().terminalStyle;
+    const consoleStyles = getInfoConfig().terminalStyle;
     adze.withEmoji.info('This is an info log.');
     expect(console.info).toHaveBeenCalledWith(
-      applyChalkStyles('ℹ️ Info      ', chalkStyles),
+      applyStyles('ℹ️ Info      ', consoleStyles),
       'This is an info log.'
     );
   });
 
   test('prints a log with level of fail with an emoji', () => {
     console.info = vi.fn();
-    const chalkStyles = getFailConfig().terminalStyle;
+    const consoleStyles = getFailConfig().terminalStyle;
     adze.withEmoji.fail('This is a fail log.');
     expect(console.info).toHaveBeenCalledWith(
-      applyChalkStyles('❌ Fail      ', chalkStyles),
+      applyStyles('❌ Fail      ', consoleStyles),
       'This is a fail log.'
     );
   });
 
   test('prints a log with level of success with an emoji', () => {
     console.info = vi.fn();
-    const chalkStyles = getSuccessConfig().terminalStyle;
+    const consoleStyles = getSuccessConfig().terminalStyle;
     adze.withEmoji.success('This is a success log.');
     expect(console.info).toHaveBeenCalledWith(
-      applyChalkStyles('🎉 Success   ', chalkStyles),
+      applyStyles('🎉 Success   ', consoleStyles),
       'This is a success log.'
     );
   });
 
   test('prints a log with level of log with an emoji', () => {
     console.log = vi.fn();
-    const chalkStyles = getLogConfig().terminalStyle;
+    const consoleStyles = getLogConfig().terminalStyle;
     adze.withEmoji.log('This is a log log.');
     expect(console.log).toHaveBeenCalledWith(
-      applyChalkStyles('🪵 Log       ', chalkStyles),
+      applyStyles('🪵 Log       ', consoleStyles),
       'This is a log log.'
     );
   });
@@ -214,10 +214,10 @@ describe('terminators with emoji', () => {
   test('prints a log with level of debug with an emoji', () => {
     console.debug = vi.fn();
     setup({ activeLevel: 'debug' });
-    const chalkStyles = getDebugConfig().terminalStyle;
+    const consoleStyles = getDebugConfig().terminalStyle;
     adze.withEmoji.debug('This is a debug log.');
     expect(console.debug).toHaveBeenCalledWith(
-      applyChalkStyles('🐞 Debug     ', chalkStyles),
+      applyStyles('🐞 Debug     ', consoleStyles),
       'This is a debug log.'
     );
   });
@@ -225,10 +225,10 @@ describe('terminators with emoji', () => {
   test('prints a log with level of verbose with an emoji', () => {
     console.debug = vi.fn();
     setup({ activeLevel: 'verbose' });
-    const chalkStyles = getVerboseConfig().terminalStyle;
+    const consoleStyles = getVerboseConfig().terminalStyle;
     adze.withEmoji.verbose('This is a verbose log.');
     expect(console.debug).toHaveBeenCalledWith(
-      applyChalkStyles('💬 Verbose   ', chalkStyles),
+      applyStyles('💬 Verbose   ', consoleStyles),
       'This is a verbose log.'
     );
   });
@@ -249,7 +249,7 @@ describe('terminators with emoji', () => {
     adze.withEmoji.custom('leetLevel', 'This is a custom log.');
 
     expect(console.log).toHaveBeenCalledWith(
-      applyChalkStyles('👾 LeetLevel ', leetLevel.terminalStyle),
+      applyStyles('👾 LeetLevel ', leetLevel.terminalStyle),
       'This is a custom log.'
     );
   });


### PR DESCRIPTION
## Context

The primary goal of this PR is to enable the use of Adze in React-native projects. RN runs on the [Hermes JS Engine](https://github.com/facebook/hermes/tree/main), although it can sometimes run in the browser context using v8 (debugging with dev tools). 

Any library that wants to be truly isomorphic and reliably run on RN can't use runtime-specific APIs (Browser API or Node API) without safeguards. We can do this on adze.

## Motivation

React-native lacks a great log library such as adze. IMO, adding support for react-native could drive community collaboration. Also, the constraints required to run on a strict EcmaScript-compliant runtime such as Hermes can help to make the library more resilient to future runtime changes.

## Details

### Replacing Chalk

The [chalk](https://github.com/chalk/chalk) library makes assumptions about the runtime it is on. The main problem is that it has side effects (runs some code when imported) that break when running it on Hermes. There are [workarounds](https://github.com/adzejs/adze/issues/175#issuecomment-2432401869) that involve patching and "polyfilling" using the Metro Bundler, but these are not ideal.

For this reason, this PR replaces chalk with [picocolors](https://github.com/alexeyraspopov/picocolors).

### Environment Checks

When running on [expo](https://expo.dev/) for android/ios, the window object is defined, although it's technically running on Hermes. The current checks are not sufficient to check if we are running in a browser. 
This PR changes the `isBrowser` function to check for additional properties in the window object, that adze expects to find.
 
 ### StructureClone Polyfill
 
 Adze makes use of the `structuredClone` function. This is a function provided by the runtimes and is not part of the language. As such, it's not implemented on Hermes, and probably won't be until (if ever) it's added to the EcmaScript spec.
 
 For this reason a polyfill for the structuredClone was added. We could revisit this later, and choose a different deep clone implementation, that doesn't rely on runtimes API.