### PR TITLE
fix: isNumber type guard to exclude arrays of a single number

### DIFF
--- a/src/functions/type-guards.ts
+++ b/src/functions/type-guards.ts
@@ -31,7 +31,7 @@ export function hasOwnProperties<
  */
 export function isNumber(value: unknown): value is number {
   // Number(null) returns 0 😭
-  return value !== null && !isNaN(Number(value));
+  return value !== null && typeof value === 'number' && !isNaN(Number(value));
 }
 
 /**


### PR DESCRIPTION
I ran into an issue while using the `store.addListener` function. While, passing an array of a single number (such as `[1]`), the listener wasn't picking up errors. I believe I tracked down the issue to the `isNumber` type guard, which was wrongly flagging those arrays as numbers.

I've added a typeof check to prevent this, as `Number([1]) === 1`