### PR TITLE
fix: exports Formatter class instead of type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ export {
   type FilterConfig,
   type Filters,
   type Format,
-  type Formatter,
+  Formatter,
   type FormatterConstructor,
   type HrTime,
   type HttpMethod,


### PR DESCRIPTION
This PR exports removes the `type` keyword from the Formatter class export. Using the type definition will cause the following error using it:

'Formatter' cannot be used as a value because it was exported using 'export type'.ts(1362)
index.d.ts(10, 201): 'Formatter' was exported here.

For example, like this:

```typescript
import { 
  Formatter,
} from 'adze';

export class CompactFormatter extends Formatter {
...
```